### PR TITLE
We move the predefined regions function to the geot_settings() function

### DIFF
--- a/src/filters.php
+++ b/src/filters.php
@@ -3,16 +3,21 @@
  * Different helpers filters used around
  */
 
-add_filter( 'geot/get_country_regions', function (){
-	$settings   = geot_settings();
-	
+add_filter( 'geot/settings_page/opts', function($settings) {
+
 	if( apply_filters('geot/enable_predefined_regions', true) ) {
 		if( isset( $settings['region'] ) )
-			$regions = array_merge($settings['region'], geot_predefined_regions());
+			$settings['region'] = array_merge($settings['region'], geot_predefined_regions());
 		else
-			$regions = geot_predefined_regions();
-	} else
-		$regions = $settings['region'];
+			$settings['region'] = geot_predefined_regions();
+	}
+
+	return $settings;
+});
+
+add_filter( 'geot/get_country_regions', function (){
+	$settings   = geot_settings();
+	$regions  = isset( $settings['region'] ) ? $settings['region'] : array();
 
 	return $regions;
 } );


### PR DESCRIPTION
To get countries regions we use geot_country_regions() function but in some code places they use geot_settings() and the first one calls to second function. So we have moved the predefined function to geot_settings().